### PR TITLE
separate `tool` from `conda_package`

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -25,12 +25,20 @@ entry:
     {% if entry == '' %}
     Please provide an entry
     {% endif %}
+conda_package:
+  type: str
+  help: What is the conda package name?
+  default: '{{ tool }}'
+  validator: >-
+    {% if conda_package == '' %}
+    Please provide a conda package name
+    {% endif %}
 description:
   type: str
   help: What is the description of the tool?
   default: This hook runs {{ tool }}.
 
 _tasks:
-  - sed -i "s/TOOL_VERSION/$(micromamba search -c conda-forge {{ tool }} --json | jq -r '.result.pkgs[0].version')/g" environment.yml
+  - sed -i "s/TOOL_VERSION/$(micromamba search -c conda-forge {{ conda_package }} --json | jq -r '.result.pkgs[0].version')/g" environment.yml
   - git init
   - git branch -M main

--- a/template/environment.yml.jinja
+++ b/template/environment.yml.jinja
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - {{ tool }}=TOOL_VERSION
+  - {{ conda_package }}=TOOL_VERSION


### PR DESCRIPTION
For some packages like https://github.com/Quantco/pre-commit-mirrors-clang-tidy/pull/23 the name of the conda package might differ from the name of the tool