### PR TITLE
Add permissions for keepalive workflow

### DIFF
--- a/template/.github/workflows/keep-alive.yml
+++ b/template/.github/workflows/keep-alive.yml
@@ -7,11 +7,8 @@ jobs:
   keep-alive:
     name: Alive
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - uses: gautamkrishnar/keepalive-workflow@14b7c72e9af14bddbbc1022a6f0bd20b1eac2619
-        with:
-          commit_message: Ah ah ah, stayin' alive
-          committer_username: ForrestQuant
-          committer_email: forrestquant@users.noreply.github.com
-          time_elapsed: 50 # days


### PR DESCRIPTION
It seems like we need to add actions: write to the permissions

https://github.com/gautamkrishnar/keepalive-workflow/compare/v1...2.0.0